### PR TITLE
Fix the delete_all_rows method

### DIFF
--- a/google_spreadsheet/api.py
+++ b/google_spreadsheet/api.py
@@ -306,5 +306,5 @@ class Worksheet(object):
         """
         entries = self._get_row_entries(self.query)
         for entry in entries:
-            self.delete_row(entry)
+            self.gd_client.DeleteRow(entry)
         self._flush_cache()

--- a/tests.py
+++ b/tests.py
@@ -166,6 +166,17 @@ class TestWorksheet(TestCase):
         assert_equals(len(delete_rows), num_rows)
         assert_equals(delete_rows[-1], rows[-1])
 
+    def test_delete_all_rows(self):
+        """Tests deleting of all rows in the sheet
+        """
+        # first retrieve rows and store in memory to re-add after test
+        rows = self.sheet.get_rows()
+        self.sheet.delete_all_rows()
+        assert_equals(len(self.sheet.get_rows()), 0)
+        # add back the rows that were there so the other tests still pass
+        for row in rows:
+          self.sheet.insert_row(row)
+
     def test_query(self):
         """Test Query.
 


### PR DESCRIPTION
It looks like there was a bad copy/paste of the wrong kind of delete line in the loop for `delete_all_rows`.

This pull request uses the right one, and adds a unit test for the `delete_all_rows` method (test failed prior to my change, passes after)

Thanks for writing this wrapper lib, it's been really helpful in working with the cludgy Google Spreadsheets API!
